### PR TITLE
#2 Changed event to use RenderedHud instead of Rendered

### DIFF
--- a/PauseInMultiplayer/PauseInMultiplayer.cs
+++ b/PauseInMultiplayer/PauseInMultiplayer.cs
@@ -66,7 +66,7 @@ namespace PauseInMultiplayer
             Helper.Events.Multiplayer.PeerConnected += Multiplayer_PeerConnected;
             Helper.Events.Multiplayer.PeerDisconnected += Multiplayer_PeerDisconnected;
 
-            Helper.Events.Display.Rendered += Display_Rendered;
+            Helper.Events.Display.RenderedHud += Display_RenderedHud;
 
             Helper.Events.Input.ButtonPressed += Input_ButtonPressed;
 
@@ -229,7 +229,7 @@ namespace PauseInMultiplayer
             Game1.player.temporarilyInvincible = false;
         }
 
-        private void Display_Rendered(object? sender, StardewModdingAPI.Events.RenderedEventArgs e)
+        private void Display_RenderedHud(object? sender, StardewModdingAPI.Events.RenderedHudEventArgs e)
         {
             if (!Context.IsWorldReady) return;
 


### PR DESCRIPTION
This change seems to solve both problems (Scaling correctly with zoom and the pause indicator sometimes being drawn over the menu).

The only downside, is there in some cases (when the toolbar is on the top, because you're close to the bottom of the map, and the UI scale is high) it draws the pause indicator over the toolbar.

Like this:
<img width="1348" alt="Screenshot 2024-04-12 at 20 40 56" src="https://github.com/mishagp/PauseInMultiplayer/assets/5023448/140043e7-6b96-4632-9372-28b5033b4b77">

But I had to lower my screen resolution to take this screenshot, so I don't feel like it would be a big problem since in most cases players don't play with such a big toolbar.