### PR TITLE
Fixed X Position when UI is scaled

### DIFF
--- a/PauseInMultiplayer/PauseInMultiplayer.cs
+++ b/PauseInMultiplayer/PauseInMultiplayer.cs
@@ -66,7 +66,7 @@ namespace PauseInMultiplayer
             Helper.Events.Multiplayer.PeerConnected += Multiplayer_PeerConnected;
             Helper.Events.Multiplayer.PeerDisconnected += Multiplayer_PeerDisconnected;
 
-            Helper.Events.Display.Rendered += Display_Rendered;
+            Helper.Events.Display.RenderedHud += Display_Rendered;
 
             Helper.Events.Input.ButtonPressed += Input_ButtonPressed;
 
@@ -178,8 +178,6 @@ namespace PauseInMultiplayer
                 getValue: () => this.config.AnyCutscenePauses,
                 setValue: value => this.config.AnyCutscenePauses = value
             );
-
-
         }
 
         private void Input_ButtonPressed(object? sender, StardewModdingAPI.Events.ButtonPressedEventArgs e)
@@ -229,15 +227,28 @@ namespace PauseInMultiplayer
             Game1.player.temporarilyInvincible = false;
         }
 
-        private void Display_Rendered(object? sender, StardewModdingAPI.Events.RenderedEventArgs e)
+        private void Display_Rendered(object? sender, StardewModdingAPI.Events.RenderedHudEventArgs e)
         {
             if (!Context.IsWorldReady) return;
-
+            
+            Game1.PushUIMode();
+            
             //draw X over time indicator
             if (shouldPause() && this.config.ShowPauseX && Game1.displayHUD)
-                Game1.spriteBatch.Draw(Game1.mouseCursors, updatePosition(), new Rectangle(269, 471, 15, 15), new Color(0, 0, 0, 64), 0f, Vector2.Zero, 4f, SpriteEffects.None, 0.91f);
-
-
+            {
+                Game1.spriteBatch.Draw(
+                    Game1.mouseCursors,
+                    updatePosition(),
+                    new Rectangle(269, 471, 15, 15),
+                    new Color(0, 0, 0, 64),
+                    0f,
+                    Vector2.Zero,
+                    4f,
+                    SpriteEffects.None,
+                    0.91f);
+            }
+            
+            Game1.PopUIMode();
         }
 
         private void Multiplayer_PeerDisconnected(object? sender, StardewModdingAPI.Events.PeerDisconnectedEventArgs e)
@@ -740,12 +751,12 @@ namespace PauseInMultiplayer
             {
                 position = new Vector2(Math.Min(position.X, -Game1.uiViewport.X + Game1.currentLocation.map.Layers[0].LayerWidth * 64 - 300), 8f);
             }
-
-            Utility.makeSafe(ref position, 300, 284);
-
+            
             position.X += 23;
             position.Y += 55;
 
+            Utility.makeSafe(ref position, 60, 60);
+            
             return position;
         }
 

--- a/PauseInMultiplayer/PauseInMultiplayer.csproj
+++ b/PauseInMultiplayer/PauseInMultiplayer.csproj
@@ -5,9 +5,9 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>false</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AssemblyVersion>1.8.0</AssemblyVersion>
-    <FileVersion>1.8.0</FileVersion>
-    <Version>1.8.0</Version>
+    <AssemblyVersion>1.8.1</AssemblyVersion>
+    <FileVersion>1.8.1</FileVersion>
+    <Version>1.8.1</Version>
     <PackageReleaseNotes>any cutscene pause option added</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/PauseInMultiplayer/manifest.json
+++ b/PauseInMultiplayer/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Pause in Multiplayer Revived",
   "Author": "mishmaash",
-  "Version": "1.8.0",
+  "Version": "1.8.1",
   "Description": "Pauses time in multiplayer when all connected players should have their time paused. Originally created by jorgamun.",
   "UniqueID": "mishmaash.PauseInMultiplayer",
   "EntryDll": "PauseInMultiplayer.dll",


### PR DESCRIPTION
#Details
- Changed `Draw_Rendering` to be called from `RenderedHUD` instead of `Rendered`. This fixed the layering issue as it seems to clock if drawn after in certain cases.
- Moved the positioning and drawing into UI Mode to fix the positioning issue. There is still a little bit of jitter (1-2 pixels at each level) but I think this is just a rounding error since `Game1.uiViewport` actually changes in width by up to 2 pixels as it scales

#Testing
- Tested in single player
- Tested in multiplayer
- Tested in local co-op